### PR TITLE
chore: introduce Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "Asia/Tokyo",
+  "dependencyDashboard": false,
+  "ignoreTests": true,
+  "automerge": false,
+  "major": {
+    "enabled": true
+  },
+  "minimumReleaseAge": "1 day",
+  "rangeStrategy": "bump",
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "schedule": ["at any time"]
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch", "minor", "major"],
+      "schedule": ["at any time"]
+    },
+    {
+      "description": "Group GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "Group Go modules",
+      "matchManagers": ["gomod"],
+      "groupName": "go-modules"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adopt the Renovate config from [shuntaka9576/gh-kanban](https://github.com/shuntaka9576/gh-kanban) so dependency updates land as grouped PRs instead of manual `go get -u all` sweeps.

- `extends: config:recommended`
- Groups: `github-actions` and `go-modules` (one PR per ecosystem)
- Major updates enabled, automerge off, 1-day `minimumReleaseAge`
- Vulnerability alerts handled at any time

## Test plan

- [ ] Make sure the Renovate GitHub App is installed on this repo
- [ ] After merge, confirm Renovate opens grouped dependency PRs (`github-actions` / `go-modules`)