### PR TITLE
fix(gh): surface gh CLI stderr in error messages

### DIFF
--- a/gh/exec.go
+++ b/gh/exec.go
@@ -1,0 +1,20 @@
+package gh
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cli/go-gh/v2"
+)
+
+func execGh(args ...string) ([]byte, error) {
+	stdout, stderr, err := gh.Exec(args...)
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			return nil, fmt.Errorf("gh %s: %w", strings.Join(args, " "), err)
+		}
+		return nil, fmt.Errorf("gh %s: %w: %s", strings.Join(args, " "), err, msg)
+	}
+	return stdout.Bytes(), nil
+}

--- a/gh/p2_fields.go
+++ b/gh/p2_fields.go
@@ -1,9 +1,5 @@
 package gh
 
-import (
-	"github.com/cli/go-gh/v2"
-)
-
 type GetProjectFieldsParams struct {
 	ProjectId string
 }
@@ -12,12 +8,10 @@ func GetProjectFields(params *GetProjectFieldsParams) (*[]byte, error) {
 	ghql := "query=" + GetProjectFieldsQuery(params.ProjectId)
 	args := append(graphqlArgs, ghql)
 
-	stdOut, _, err := gh.Exec(args...)
+	bytes, err := execGh(args...)
 	if err != nil {
 		return nil, err
 	}
-
-	bytes := stdOut.Bytes()
 
 	return &bytes, nil
 }

--- a/gh/p2_issue.go
+++ b/gh/p2_issue.go
@@ -1,9 +1,5 @@
 package gh
 
-import (
-	"github.com/cli/go-gh/v2"
-)
-
 type CreateDraftIssueParams struct {
 	ProjectId  string
 	Title      string
@@ -13,15 +9,12 @@ type CreateDraftIssueParams struct {
 func CreateDraftIssue(params *CreateDraftIssueParams) (*[]byte, error) {
 	ghql := "query=" + GetDraftIssueMutation(params.ProjectId, params.Title, "", params.AssiginIds)
 	args := append(graphqlArgs, ghql)
-	stdOut, _, err := gh.Exec(args...)
-
+	bytes, err := execGh(args...)
 	if err != nil {
 		return nil, err
 	}
 
-	byte := stdOut.Bytes()
-
-	return &byte, nil
+	return &bytes, nil
 }
 
 type CreateIssueParams struct {
@@ -35,15 +28,12 @@ type CreateIssueParams struct {
 func CreateIssue(params *CreateIssueParams) (*[]byte, error) {
 	ghql := "query=" + IssueMutation(params.RepositoryId, params.Title, params.Body, params.AssigneeIds, params.LabelIds)
 	args := append(graphqlArgs, ghql)
-	stdOut, _, err := gh.Exec(args...)
+	bytes, err := execGh(args...)
 	if err != nil {
 		return nil, err
 	}
 
-	byte := stdOut.Bytes()
-
-	return &byte, nil
-
+	return &bytes, nil
 }
 
 type AddItemParams struct {
@@ -54,13 +44,10 @@ type AddItemParams struct {
 func AddItem(params *AddItemParams) (*[]byte, error) {
 	ghql := "query=" + AddItemMutation(params.ProjectId, params.ContentId)
 	args := append(graphqlArgs, ghql)
-	stdOut, _, err := gh.Exec(args...)
-
+	bytes, err := execGh(args...)
 	if err != nil {
 		return nil, err
 	}
-
-	bytes := stdOut.Bytes()
 
 	return &bytes, nil
 }
@@ -76,13 +63,10 @@ type UpdateItemParams struct {
 func UpdateItem(params *UpdateItemParams) (*[]byte, error) {
 	ghql := "query=" + UpdateItemMutation(params.ProjectId, params.ItemId, params.FieldId, params.ValueType, params.Value)
 	args := append(graphqlArgs, ghql)
-	stdOut, _, err := gh.Exec(args...)
-
+	bytes, err := execGh(args...)
 	if err != nil {
 		return nil, err
 	}
-
-	bytes := stdOut.Bytes()
 
 	return &bytes, nil
 }

--- a/gh/p2_items.go
+++ b/gh/p2_items.go
@@ -1,9 +1,5 @@
 package gh
 
-import (
-	"github.com/cli/go-gh/v2"
-)
-
 type GetProjectItemsParams struct {
 	ProjectId string
 	Cursor    *string
@@ -13,12 +9,10 @@ func GetProjectItems(params *GetProjectItemsParams) (*[]byte, error) {
 	ghql := "query=" + GetProjectItemsQuery(params.ProjectId, params.Cursor)
 	args := append(graphqlArgs, ghql)
 
-	stdOut, _, err := gh.Exec(args...)
+	bytes, err := execGh(args...)
 	if err != nil {
 		return nil, err
 	}
-
-	bytes := stdOut.Bytes()
 
 	return &bytes, nil
 }

--- a/gh/p2_label.go
+++ b/gh/p2_label.go
@@ -1,10 +1,6 @@
 package gh
 
-import (
-	"encoding/json"
-
-	"github.com/cli/go-gh/v2"
-)
+import "encoding/json"
 
 type Label struct {
 	Id          int64  `json:"id"`
@@ -18,15 +14,13 @@ type Label struct {
 func CreateLabel(owner string, repo string, labelName string) (*Label, error) {
 	args := CreateLabelApiArgs(owner, repo, labelName)
 
-	stdout, _, err := gh.Exec(args...)
+	stdout, err := execGh(args...)
 	if err != nil {
 		return nil, err
 	}
 
 	label := &Label{}
-	err = json.Unmarshal(stdout.Bytes(), label)
-
-	if err != nil {
+	if err := json.Unmarshal(stdout, label); err != nil {
 		return nil, err
 	}
 
@@ -36,15 +30,13 @@ func CreateLabel(owner string, repo string, labelName string) (*Label, error) {
 func GetLabel(owner string, repo string, labelName string) (*Label, error) {
 	args := GetLabelApiArgs(owner, repo, labelName)
 
-	stdout, _, err := gh.Exec(args...)
+	stdout, err := execGh(args...)
 	if err != nil {
 		return nil, err
 	}
 
 	label := &Label{}
-	err = json.Unmarshal(stdout.Bytes(), label)
-
-	if err != nil {
+	if err := json.Unmarshal(stdout, label); err != nil {
 		return nil, err
 	}
 

--- a/gh/p2_list.go
+++ b/gh/p2_list.go
@@ -1,7 +1,5 @@
 package gh
 
-import "github.com/cli/go-gh/v2"
-
 type ListProjectParams struct {
 	ClientType ClientType
 	Name       string
@@ -10,13 +8,10 @@ type ListProjectParams struct {
 func ListProject(params *ListProjectParams) (*[]byte, error) {
 	ghql := "query=" + GetListQuery(params.ClientType, params.Name)
 	args := append(graphqlArgs, ghql)
-	stdOut, _, err := gh.Exec(args...)
-
+	bytes, err := execGh(args...)
 	if err != nil {
 		return nil, err
 	}
-
-	bytes := stdOut.Bytes()
 
 	return &bytes, nil
 }

--- a/gh/p2_repo.go
+++ b/gh/p2_repo.go
@@ -1,9 +1,5 @@
 package gh
 
-import (
-	"github.com/cli/go-gh/v2"
-)
-
 type GetRepoParams struct {
 	Owner string
 	Repo  string
@@ -12,13 +8,10 @@ type GetRepoParams struct {
 func GetRepo(params *GetRepoParams) (*[]byte, error) {
 	ghql := "query=" + GetRepoQuery(params.Owner, params.Repo)
 	args := append(graphqlArgs, ghql)
-	stdOut, _, err := gh.Exec(args...)
-
+	bytes, err := execGh(args...)
 	if err != nil {
 		return nil, err
 	}
 
-	byte := stdOut.Bytes()
-
-	return &byte, nil
+	return &bytes, nil
 }

--- a/gh/p2_user.go
+++ b/gh/p2_user.go
@@ -1,19 +1,12 @@
 package gh
 
-import (
-	"github.com/cli/go-gh/v2"
-)
-
 func GetUser(users []string) (*[]byte, error) {
 	ghql := "query=" + GetUserQuery(users)
 	args := append(graphqlArgs, ghql)
-	stdOut, _, err := gh.Exec(args...)
-
+	bytes, err := execGh(args...)
 	if err != nil {
 		return nil, err
 	}
-
-	bytes := stdOut.Bytes()
 
 	return &bytes, nil
 }


### PR DESCRIPTION
## Problem

Running `gh p2 create` (or any other gh-p2 command) that hits an underlying `gh` failure prints only:

```
gh execution failed: exit status 1
```

The real stderr from the `gh` invocation is dropped on the floor, so there is no way to tell whether the failure was authorization, a missing project, an invalid GraphQL field, etc.

## Cause

Every `gh.Exec(args...)` call site used `stdOut, _, err` and discarded the stderr buffer.

## Fix

- Add `gh/exec.go` with a small `execGh` wrapper that captures stderr and folds it into the returned error along with the args that were run
- Route every `gh.Exec` call site (`p2_user.go`, `p2_items.go`, `p2_list.go`, `p2_issue.go`, `p2_fields.go`, `p2_label.go`, `p2_repo.go`) through `execGh`
- Drop the now-unused `github.com/cli/go-gh/v2` imports from those files

After this, the same failure will surface as something like:

```
gh api graphql -f query=...: exit status 1: Could not resolve to a node with the global id of 'XXX'
```

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [ ] Reproduce a failing `gh p2 create` and confirm the message now includes the underlying gh stderr