### PR TITLE
fix(create): require --repo or --draft

### DIFF
--- a/cli/create.go
+++ b/cli/create.go
@@ -30,6 +30,10 @@ func (c *Cmd) Create(params *CreateParamas) error {
 
 			return errors.New("exec create error: error specifying flags when creating draft")
 		}
+	} else if params.Repo == "" {
+		fmt.Fprintf(os.Stderr, "Specify either --repo or --draft. Use --repo <name> to create an issue in a repository, or --draft to create a draft item directly in the project.\n")
+
+		return errors.New("exec create error: --repo or --draft is required")
 	}
 
 	// get project status item


### PR DESCRIPTION
## Problem

Running `gh p2 create` with neither `--repo` nor `--draft` produced an opaque failure that bubbled up from the underlying `gh api` call:

```
gh p2 create -u shuntaka9576 --project-title=test --title=a
# before #14: gh execution failed: exit status 1
# after  #14: gh api graphql ...: ...: Could not resolve to a Repository with the name 'shuntaka9576/'.
```

The CLI was silently calling `GetRepo` with an empty repo name. The user has to know that `--repo` is required for issue creation and `--draft` is required for draft items.

## Fix

Reject the combination at the CLI layer with a message that explains both paths:

```
$ gh p2 create -u shuntaka9576 --project-title=test --title=a
Specify either --repo or --draft. Use --repo <name> to create an issue in a repository, or --draft to create a draft item directly in the project.
exec create error: --repo or --draft is required
```

## Test plan

- [x] `go build ./...`
- [x] `go run ./cmd/p2 create -u shuntaka9576 --project-title=test --title=a` now exits with the new message
- [ ] Sanity-check that `--draft` and `--repo=<name>` still create issues as before