### PR TITLE
ci: follow go.mod instead of running matrix over all Go versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,32 +1,18 @@
-name: "test"
+name: test
 on:
   push:
     branches:
-    - "**"
-
+      - "**"
 jobs:
-  go-versions:
+  test:
     runs-on: ubuntu-latest
-    outputs:
-      versions: ${{ steps.versions.outputs.versions }}
     steps:
-      - id: versions
-        run: |
-          versions=$(curl -s 'https://go.dev/dl/?mode=json' | jq -c 'map(.version[2:])')
-          echo "versions=$versions" >> $GITHUB_OUTPUT
-  ci:
-    name: "Run CI"
-    needs: go-versions
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: ${{fromJson(needs.go-versions.outputs.versions)}}
-    steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        fetch-depth: 1
-    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version: ${{ matrix.go-version }}
-    - run: "go test -v ./..."
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - run: go vet ./...
+      - run: go build ./...
+      - run: go test ./...


### PR DESCRIPTION
## Problem

`main` CI is failing after #16 (Renovate) bumped `go.mod`'s go directive to `1.26.4`. The `test.yml` matrix pulls every released Go version from `go.dev/dl`, and `actions/setup-go@v6` runs with `GOTOOLCHAIN=local`, so older jobs (e.g. 1.25.11) get:

```
go: go.mod requires go >= 1.26.4 (running go 1.25.11; GOTOOLCHAIN=local)
```

The matrix design predates the go.mod directive being a hard floor; with it set to the current toolchain it cannot be honored on older Go.

## Fix

Match the gh-kanban test workflow:

- Drop `go-versions` + matrix
- Use `actions/setup-go` with `go-version-file: go.mod` so CI always tracks the directive Renovate bumps
- Add `go vet ./...` and `go build ./...` alongside `go test ./...`

## Test plan

- [ ] CI on this PR is green
- [ ] After merge, `main` test workflow goes green